### PR TITLE
Don't look for janet headers if $janetheadercflags is non-empty

### DIFF
--- a/configure
+++ b/configure
@@ -43,16 +43,18 @@ EOF
   return "$ok"
 }
 
-echo "Looking for janet headers..."
-if ! check_janet_headers
-then
-  echo "janet headers not found, trying pkg-config..."
-  janetheadercflags=$(pkg-config --cflags janet)
-fi
-if ! check_janet_headers
-then
-  fail "unable to find working janet headers."
-  exit 1
+if [ -z "$janetheadercflags" ]; then
+  echo "Looking for janet headers..."
+  if ! check_janet_headers
+  then
+    echo "janet headers not found, trying pkg-config..."
+    janetheadercflags=$(pkg-config --cflags janet)
+  fi
+  if ! check_janet_headers
+  then
+    fail "unable to find working janet headers."
+    exit 1
+  fi
 fi
 
 CFLAGS="-fPIC ${CFLAGS} ${janetheadercflags}"


### PR DESCRIPTION
The `--janet-header-cflags` option is currently useless as it either overwrites it or exits if it cannot find it; this pull request fixes this.