### PR TITLE
Allow passing LDFLAGS through arguments

### DIFF
--- a/configure
+++ b/configure
@@ -26,6 +26,7 @@ for arg ; do
   --janet-header-cflags=*) JANET_HEADER_CFLAGS=${arg#*=} ;;
   CC=*) CC=${arg#*=} ;;
   CFLAGS=*) CFLAGS=${arg#*=} ;;
+  LDFLAGS=*) LDFLAGS=${arg#*=} ;;
   --help) usage ;;
   *) fail "unknown option '$arg'"
   esac


### PR DESCRIPTION
You can easily set it by prefixing it before the script instead, but the others are supported through arguments and the usage specifies that this should work.