### PR TITLE
More accurate checker for implicit parens

### DIFF
--- a/janetsh
+++ b/janetsh
@@ -111,11 +111,14 @@
     (buffer/push-string buf ln "\n")
     buf))
 
+(def- implicit-checker-peg
+  (peg/compile '(not (* (any (set " \t\r\f\v")) (set `"(@[{`)))))
+
 (defn- want-implicit-parens [buf p]
   (and (not *parens*)
        (> (length buf) 1)
        (empty? (parser/state p))
-       (not (find (partial = (buf 0)) [34 40 64 91 123])))) # " ( @ [ {
+       (peg/match implicit-checker-peg buf)))
 
 (defn- getchunk [buf p]
   (sh/update-all-jobs-status)


### PR DESCRIPTION
Leading whitespace currently confuses the checker. This commit uses a peg instead to make the check account for leading whitespace.