### PR TITLE
Change signal handlers when running scripts.

### DIFF
--- a/src/janetsh
+++ b/src/janetsh
@@ -3,7 +3,6 @@
 (import shlib)
 (import sh)
 
-(sh/init)
 
 (var *sysrc-file* "/etc/janetsh.rc")
 (var *rc-file* (string (os/getenv "HOME") "/.janetsh.rc"))
@@ -64,6 +63,10 @@
   (fn *get-prompt* [p]
     (string (os/cwd) " " (parser/state p) "$ ")))
 
+
+(if *script*
+  (sh/init true)
+  (sh/init false))
 
 (var *get-completions*
   (fn *get-completions*

--- a/src/shlib/shlib.c
+++ b/src/shlib/shlib.c
@@ -370,7 +370,13 @@ static Janet set_noninteractive_signal_handlers(int32_t argc, Janet *argv) {
   memset(&act, 0, sizeof(act));
   act.sa_handler = SIG_IGN;
 
-  if (sigaction(SIGPIPE, &act, NULL) == -1)
+  if ( (sigaction(SIGPIPE, &act, NULL) == -1)
+    /* 
+       Not totally certain about ignoring this signal, but
+       When it is enabled, our terminal is stopped after a tcsetpgrp
+       call for configuring a child.
+    */
+    || (sigaction(SIGTTOU, &act, NULL) == -1))
     janet_panic("sigaction: error");
   
   sigset_t block_mask;


### PR DESCRIPTION
We want to respond to SIGINT when running a script
but also allow scripts to start processes like vim,
this change allows that.