### PR TITLE
Add support for shell aliases

### DIFF
--- a/src/sh.janet
+++ b/src/sh.janet
@@ -29,6 +29,9 @@
 # signals disabled...
 (var unsafe-child-cleanup-array nil)
 
+# Stores defined aliases
+(var *aliases* @{})
+
 # Reentrancy counter for shell signals...
 (var disable-cleanup-signals-count 0)
 
@@ -606,6 +609,74 @@
         (file/write stdout "\x1b[H\x1b[2J"))
   })
 
+(defn- make-alias-builtin
+  []
+  @{
+    :pre-fork
+      (fn builtin-alias [self args]
+        (var fst (first args))
+        (cond
+           (= fst "-h") nil
+           (empty? args) nil
+           (and (= (length args) 1) (= (*aliases* fst) nil))
+             (put self :error (string "alias: " fst " not found"))
+           (= (length args) 1) nil
+
+           # put specific alias
+           (when-let [alias fst
+                      cmd (tuple/slice args 1)]
+             (put *aliases* alias cmd))))
+    :post-fork
+      (fn builtin-alias [self args]
+        (var fst (first args))
+        (cond
+          (self :error) (error (self :error))
+          (= fst "-h")
+            (file/write stdout "alias name [commands]\n")
+          (empty? args)
+            (each [alias cmd] (pairs *aliases*)
+              (file/write stdout
+                (string "alias " alias " " (string/join cmd " ") "\n")))
+          (= (length args) 1)
+            (when-let [alias fst
+                       cmd (*aliases* alias)]
+              (file/write stdout
+                (string "alias " alias " " (string/join cmd " ") "\n")))))
+    :error nil
+  })
+
+(defn- make-unalias-builtin
+  []
+  @{
+    :pre-fork
+      (fn builtin-unalias [self args]
+        (var fst (first args))
+        (case fst
+          nil nil
+          "-h" nil
+          "-a"
+            # unalias all
+            (each alias (keys *aliases*)
+              (put *aliases* alias nil))
+
+          (each alias args
+            (if-not (nil? (*aliases* alias))
+              (put *aliases* alias nil)
+              (put self :error (string "unalias: " fst " not found")))
+            )))
+    :post-fork
+      (fn builtin-unalias [self args]
+        (var fst (first args))
+        (case fst
+          nil
+            (print "unalias [-a] name [name ...]")
+          "-h"
+            (print "unalias [-a] name [name ...]")
+          "-a"
+          (self :error) (error (self :error))))
+    :error nil
+  })
+
 # Table of builtin name to constructor
 # function for builtin objects.
 #
@@ -615,12 +686,20 @@
 (var *builtins* @{
   "clear" make-clear-builtin
   "cd" make-cd-builtin
+  "alias" make-alias-builtin
+  "unalias" make-unalias-builtin
 })
 
 (defn- replace-builtins
   [args]
   (when-let [bi (*builtins* (first args))]
     (put args 0 (bi)))
+  args)
+
+(defn- replace-aliases
+    [args]
+  (when-let [bi (*aliases* (first args))]
+    (put args 0 bi))
   args)
 
 (defn parse-job
@@ -662,7 +741,9 @@
     (error "empty shell job"))
   
   (each proc (job :procs)
-    (put proc :args (tuple replace-builtins (tuple flatten (proc :args)))))
+    (put proc :args
+      (tuple replace-builtins (tuple flatten
+        (tuple replace-aliases (tuple flatten (proc :args)))))))
 
   [job fg])
 

--- a/test/cases/0016-aliases
+++ b/test/cases/0016-aliases
@@ -1,0 +1,34 @@
+#! /usr/bin/env janetsh
+
+(import sh)
+
+(sh/$$_ alias x xxx)
+(sh/$$_ alias y yyy)
+(sh/$$_ alias z zzz)
+
+# all aliases printed
+(when (not= (sh/$$_? alias) ["alias x xxx\nalias y yyy\nalias z zzz" 0]) (error "fail"))
+
+# only requested alias printed
+(when (not= (sh/$$_? alias x) ["alias x xxx" 0]) (error "fail"))
+
+# non-existing alias errs
+(when (not= (sh/$$_? alias a :2>/dev/null) ["" 1]) (error "fail"))
+
+# non-existing alias errs
+(when (not= (sh/$$_? unalias a :2>/dev/null) ["" 1]) (error "fail"))
+
+# still all aliases are present
+(when (not= (sh/$$_? alias) ["alias x xxx\nalias y yyy\nalias z zzz" 0]) (error "fail"))
+
+# errs because of non-existing while removing existing one
+(when (not= (sh/$$_? unalias a z :2>/dev/null) ["" 1]) (error "fail"))
+
+# the removed alias is not present
+(when (not= (sh/$$_? alias) ["alias x xxx\nalias y yyy" 0]) (error "fail"))
+
+# removes all aliases
+(when (not= (sh/$$_? unalias -a) ["" 0]) (error "fail"))
+
+# no aliases left
+(when (not= (sh/$$_? alias) ["" 0]) (error "fail"))


### PR DESCRIPTION
Adds support for shell aliases with new builtins `alias` & `unalias`. 
```
$ alias ll ls -Alhp
0
$ alias
alias ll ls -Alhp
0
$ alias nope
error: alias: nope not found
1
$ unalias -a
0
```
