### PR TITLE
WIP: Run hook functions before & after line execution

### DIFF
--- a/src/janetsh
+++ b/src/janetsh
@@ -11,6 +11,7 @@
 (var *handleopts* true)
 (var *pre-exec-hook* nil)
 (var *post-exec-hook* nil)
+(var *post-crash-exec-hook* nil)
 
 (def- user-env (fiber/getenv (fiber/current)))
 
@@ -166,7 +167,13 @@
     ~(do
        (if (function? *pre-exec-hook*)
          (apply *pre-exec-hook* ,expresion_type [',f]))
-       (var ,$res (do ,;f))
+       (var ,$res
+             (try
+               (do ,;f)
+               ([e]
+                (if (function? *post-crash-exec-hook*)
+                  (apply *post-crash-exec-hook* ,expresion_type ',f [e]))
+                (error e))))
        (if (function? *post-exec-hook*)
          (apply *post-exec-hook* ,expresion_type ',f [,$res]))
      ,$res)))

--- a/src/janetsh
+++ b/src/janetsh
@@ -9,6 +9,8 @@
 (var *script* nil)
 (var *parens* false)
 (var *handleopts* true)
+(var *pre-exec-hook* nil)
+(var *post-exec-hook* nil)
 
 (def- user-env (fiber/getenv (fiber/current)))
 
@@ -158,15 +160,26 @@
        (empty? (parser/state p))
        (peg/match implicit-checker-peg buf)))
 
+(defmacro- hookit
+  [expresion_type & f]
+  (with-syms [$res]
+    ~(do
+       (if (function? *pre-exec-hook*)
+         (apply *pre-exec-hook* ,expresion_type [',f]))
+       (var ,$res (do ,;f))
+       (if (function? *post-exec-hook*)
+         (apply *post-exec-hook* ,expresion_type ',f [,$res]))
+     ,$res)))
+
 (defn- getchunk [buf p]
   (sh/update-all-jobs-status)
   (def prompt (try (*get-prompt* p) ([e] "$ ")))
   (when (getline prompt buf)
-    (when (want-implicit-parens buf p)
-      (let [line (string buf)]
-        (buffer/clear buf)
-        (buffer/format buf "(sh/$? %s)\n" line)))
-    buf))
+    (let [line (string buf)]
+      (buffer/clear buf)
+      (if (want-implicit-parens line p)
+        (buffer/format buf "(hookit :shell (sh/$? %s))\n" line)
+        (buffer/format buf "(hookit :janet %s)\n" line)))))
 
 (setdyn :pretty-format "%.40p")
 

--- a/src/janetsh
+++ b/src/janetsh
@@ -9,8 +9,29 @@
 (var *script* nil)
 (var *parens* false)
 (var *handleopts* true)
+
+
+# function should accept:
+# - type of expression:
+#     :shell -- when is a regular command (without paranes)
+#     :janet -- when is a Janet expression
+# - quoted expression to be executed
 (var *pre-exec-hook* nil)
+
+# function should accept:
+# - type of expression:
+#  :shell -- when is a regular command (without paranes)
+#  :janet -- when is a Janet expression
+# - quoted expression to be executed
+# - result returned by expression
 (var *post-exec-hook* nil)
+
+# function should accept:
+# - type of expression:
+#  :shell -- when is a regular command (without paranes)
+#  :janet -- when is a Janet expression
+# - quoted expression to be executed
+# - error thrown by expression
 (var *post-crash-exec-hook* nil)
 
 (def- user-env (fiber/getenv (fiber/current)))


### PR DESCRIPTION
Runs `*pre-exec-hook*` & `*post-exec-hook*` functions before/after execution of a line. Can be used to time how long a command took:
```janet
(var *last-command-duration* 0)
(var last-command-start 0)

(var *pre-exec-hook* (fn [&] (set last-command-start (os/clock))))
(var *post-exec-hook* (fn [&]
                        (set *last-command-duration*
                             (- (os/clock) last-command-start))))

```