### PR TITLE
Add '$-pipe' and 'pipes'.

### DIFF
--- a/src/shlib/shlib.c
+++ b/src/shlib/shlib.c
@@ -137,17 +137,6 @@ static Janet open_(int32_t argc, Janet *argv) {
   return janet_wrap_integer(fd);
 }
 
-static Janet read_(int32_t argc, Janet *argv) {
-  janet_fixarity(argc, 2);
-  int fd = janet_getinteger(argv, 0);
-  JanetBuffer *buf = janet_getbuffer(argv, 1);
-  int n = read(fd, buf->data, buf->count);
-  if (fd == -1)
-    panic_errno("read", errno);
-
-  return janet_wrap_integer(n);
-}
-
 static Janet close_(int32_t argc, Janet *argv) {
   janet_fixarity(argc, 1);
   if (close((int)janet_getnumber(argv, 0)) == -1)
@@ -575,7 +564,6 @@ static const JanetReg cfuns[] = {
     {"dup2", dup2_, NULL},
     {"kill", kill_, NULL},
     {"open", open_, NULL},
-    {"read", read_, NULL},
     {"close", close_, NULL},
     {"pipe", pipe_, NULL},
     {"waitpid", waitpid_, NULL},

--- a/support/ci.sh
+++ b/support/ci.sh
@@ -2,7 +2,7 @@
 
 set -uex
 
-janetver="cc1ff9125ad504b3d9844624e0c31f56b2ba759b"
+janetver="95eb54045fe124b83298666d38404f5bff46f515"
 janeturl="https://github.com/janet-lang/janet/archive/${janetver}.tar.gz"
 mkdir -p ci_builds
 prefix="$(readlink -f ./ci_builds)/installed"

--- a/test/cases/0002-basic-jobs
+++ b/test/cases/0002-basic-jobs
@@ -52,6 +52,9 @@
 (when (sh/$?? false)
   (error "fail"))
 
+(when (not= (sh/$$? cat < (sh/$-pipe echo hello) ) ["hello\n" 0] )
+  (error "fail"))
+
 (def j1 (sh/$ sleep "0.1" &))
 (def j2 (sh/$ sleep "120" &))
 (sh/wait-for-job j1)


### PR DESCRIPTION
'pipes' returns two files that can be
used in redirects, $-pipe returns a pipe
that can be used to read the job output.

Here are some examples of usage:

($$ cat < ($-pipe echo hello))
(file/read ($-pipe echo hello) :all)
(var [a b] (pipes))
($ ls > [b] &)
(file/read a :all)