### PR TITLE
WIP: Escape non janet values from the repl as a string

### DIFF
--- a/src/janetsh
+++ b/src/janetsh
@@ -62,7 +62,7 @@
 
 (var *get-prompt*
      (fn *get-prompt* [p]
-       (string (sh/shrink-path (os/cwd)) " " (parser/state p) "$ ")))
+       (string (sh/shrink-path (os/cwd)) " " (parser/state p :delimiters) "$ ")))
 
 (if *script*
   (sh/init true)
@@ -83,8 +83,57 @@
 (defn- want-implicit-parens [buf p]
   (and (not *parens*)
        (> (length buf) 1)
-       (empty? (parser/state p))
+       (empty? (parser/state p :delimiters))
        (peg/match implicit-checker-peg buf)))
+
+(def- symchars
+  "peg for valid janet symbol characters."
+  '(+ (range "09" "AZ" "az" "\x80\xFF") (set "!$%&*+-./:<?=>@^_|")))
+
+# Taken from https://github.com/bakpakin/mendoza/blob/master/mendoza/markup.janet
+(def- janet-value
+  "Grammar to detect valid janet values. Note this does not allow for a 'bare'
+symbol as a value, only structs, arrays, tuples, etc."
+  ~{:ws (set " \v\t\r\f\n\0")
+    :readermac (set "';~,")
+    :symchars ,symchars
+    :token (some :symchars)
+    :hex (range "09" "af" "AF")
+    :escape (* "\\" (+ (set "ntrvzf0e\"\\") (* "x" :hex :hex)))
+    :comment (* "#" (any (if-not (+ "\n" -1) 1)))
+    :symbol (if-not (range "09") :token)
+    :bytes (* (? "@") "\"" (any (+ :escape (if-not "\"" 1))) "\"")
+    :long-bytes {:delim (some "`")
+                 :open (capture :delim :n)
+                 :close (cmt (* (not (> -1 "`")) (-> :n) ':delim) ,=)
+                 :main (drop (* (? "@") :open (any (if-not :close 1)) :close))}
+    :number (drop (cmt ':token ,scan-number))
+    :raw-value (+ :comment :number :bytes :long-bytes
+                  :ptuple :btuple :struct :symbol)
+    :value (* (any (+ :ws :readermac)) :raw-value)
+    :root (any :value)
+    :root2 (any (* :value :value))
+    :ptuple (* (? "@") "(" :root (any :ws) ")")
+    :btuple (* (? "@") "[" :root (any :ws) "]")
+    :struct (* (? "@") "{" :root2 (any :ws) "}")
+    :main (+ :btuple :struct :ptuple)})
+
+(defn- as-str [s]
+  (string `"` s `"`))
+
+(def- janetsh-grammar
+  "Grammar to escape the non janet values with strings."
+  ~{:ws (capture (set " \v\t\r\f\n\0"))
+    :janet (capture (drop ,janet-value))
+    :pipe (capture "|")
+    :redirect (capture (set "<>"))
+    :token (/ (capture (some ,symchars)) ,as-str)
+    :value (+ :janet :pipe :redirect :token :ws)
+    :main (% (any :value))})
+
+(defn- escape-raw-line [line]
+  "Escape the non-janet values in 'line' as strings."
+  (get (peg/match janetsh-grammar line) 0))
 
 (defn- getchunk [buf p]
   (sh/update-all-jobs-status)
@@ -93,7 +142,7 @@
     (when (want-implicit-parens buf p)
       (let [line (string buf)]
         (buffer/clear buf)
-        (buffer/format buf "(sh/$? %s)\n" line)
+        (buffer/format buf "(sh/$? %s)\n" (escape-raw-line line))
         true))))
 
 (var *show-exit-code* true)

--- a/support/ci.sh
+++ b/support/ci.sh
@@ -2,7 +2,7 @@
 
 set -uex
 
-janetver="95eb54045fe124b83298666d38404f5bff46f515"
+janetver="9c89d1c658a11a40c4a97bd88a9321382c26fda5"
 janeturl="https://github.com/janet-lang/janet/archive/${janetver}.tar.gz"
 mkdir -p ci_builds
 prefix="$(readlink -f ./ci_builds)/installed"


### PR DESCRIPTION
Fixes #211 

This isn't done, but I wanted to get it up to see what you thought of the idea. Essentially it's just doing essentially what (I think) @bakpakin was suggesting. We add our own peg for janetsh, which allows embedded janet values, but also raw tokens that are not limited to valid janet symbols. Those tokens are then escaped as strings before being passed to `($ ...)`.

This seems to work, but I could be missing something. Or there could be a better way to do this. For example, we might want to expose something to the user that they could call like `($-raw "ls 1.png")` or something.

Note also this is my first time writing a PEG, so if things can be done more cleanly, let me know. 